### PR TITLE
Publish body transforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs
 					roscpp
 					roslib
 					tf)
+add_definitions("-std=c++11")
 # Find OpenNI2
 #find_package(PkgConfig)
 #pkg_check_modules(OpenNI2 REQUIRED libopenni2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ find_library(Nite2_LIBRARY
 
 catkin_package()
 
-include_directories(${catkin_INCLUDEDIR}
+include_directories(${catkin_INCLUDE_DIRS}
 		    ${OpenNI2_INCLUDEDIR}
 		    ${Nite2_INCLUDEDIR})
 add_executable(openni2_tracker src/openni2_tracker.cpp)


### PR DESCRIPTION
I don't know what the state of the code on `hydro-devel` was, but it definitely wasn't publishing any transforms. Ideally this should go on a new `kinetic-devel` branch, but it should be backwards compatible either way.

This deletes a bunch of commented code that was copied from `openni_tracker` and does the minimal amount of work to replicate the TF output of `openni_tracker` using NiTE 2 and openni2.